### PR TITLE
fixed digital read issue

### DIFF
--- a/Arduino/Arduino.ino
+++ b/Arduino/Arduino.ino
@@ -23,6 +23,7 @@ int back = 0;
 int left = 0;
 int right = 0;
 
+//digital interpretation of analogRead = 1024 / 5V * measured voltage
 int logicHighCutOff = 550;
 int logicLowCutOff = 60;
 

--- a/Arduino/Arduino.ino
+++ b/Arduino/Arduino.ino
@@ -23,6 +23,8 @@ int back = 0;
 int left = 0;
 int right = 0;
 
+int logicHighCutOff = 550;
+int logicLowCutOff = 60;
 
 //SPEEDS
 int drivingSpeed = 150;
@@ -98,10 +100,10 @@ void setup() {
 
 void loop() {
 //UPDATING THE BOOLEANS
-go = digitalRead(drive);
-back = digitalRead(reverse);
-left = digitalRead(leftTurn);
-right = digitalRead(rightTurn);
+go = analogToDigitalRead(drive);
+back = analogToDigitalRead(reverse);
+left = analogToDigitalRead(leftTurn);
+right = analogToDigitalRead(rightTurn);
 
 
 /////FORWARD DRIVE/////////////////////////////////////////
@@ -175,4 +177,19 @@ else{
     speedSet(MotorBoth, 0);
     Serial.println("STOP");
 }
+}
+
+
+bool analogToDigitalRead(int pin){
+    if (analogRead(pin)>logicHighCutOff){
+        return true;
+    }
+    else if (analogRead(pin)<logicLowCutOff)
+    {
+        return false;
+    }
+    else{
+        return false;
+    }
+
 }


### PR DESCRIPTION
RPI has 3V3 IO logic, Arduino has 5V IO logic and has Logic high cutoff at 3V3. This might cause issues that are resolved by analogRead with custom cutoff instead of plain digitalRead.